### PR TITLE
Close session prevent session locking

### DIFF
--- a/classes/external/view_videotime.php
+++ b/classes/external/view_videotime.php
@@ -75,6 +75,8 @@ trait view_videotime {
         require_login($course, false, $cm);
         require_capability('mod/videotime:view', $context);
 
+        \core\session\manager::write_close();
+        
         $moduleinstance = videotime_instance::instance_by_id($cm->instance);
 
         // Trigger course_module_viewed event and completion.

--- a/classes/external/view_videotime.php
+++ b/classes/external/view_videotime.php
@@ -76,7 +76,7 @@ trait view_videotime {
         require_capability('mod/videotime:view', $context);
 
         \core\session\manager::write_close();
-        
+
         $moduleinstance = videotime_instance::instance_by_id($cm->instance);
 
         // Trigger course_module_viewed event and completion.


### PR DESCRIPTION
## Problem
The function `mod_videotime_view_videotime` in `mod_videotime` is registered as type `'write'` in `db/services.php`, which means Moodle keeps the user session open during execution. This can cause session locking issues during periods of heavy load, potentially blocking the session and negatively impacting user experience and performance.

## Technical Details
```php
'mod_videotime_view_videotime' => [
    'type' => 'write',
    'ajax' => true,
    // ...
]
```

The implementation in `classes/external/view_videotime.php` does not close the session after permission checks, so the session remains locked for the entire request duration:

```php
public static function view_videotime($cmid) {
    // ...
    require_login($course, false, $cm);
    require_capability('mod/videotime:view', $context);
    // Session remains open here
    $moduleinstance = videotime_instance::instance_by_id($cm->instance);
    videotime_view($moduleinstance, $course, $cm, $context);
    return null;
}
```

## Suggested Fix
To avoid session locking issues, close the session after authentication and capability checks:

```php
require_login($course, false, $cm);
require_capability('mod/videotime:view', $context);
\core\session\manager::write_close(); // Add this line to release session lock
```

## Benefit
This change will:
- Reduce risk of performance bottlenecks on high-traffic sites

## References
Discussion: [Session unlocking ](https://docs.moodle.org/dev/Session_locks#Session_unlocking)
