### PR TITLE
VID-1130: Implement Embed tab Pro-only (soft dependency)

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -28,10 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.3'
+          - php: '8.4'
             moodle-branch: 'main'
             database: 'pgsql'
-          - php: '8.2'
+          - php: '8.3'
             moodle-branch: 'main'
             database: 'pgsql'
           - php: '8.2'

--- a/classes/hook/dndupload_register.php
+++ b/classes/hook/dndupload_register.php
@@ -48,7 +48,7 @@ final class dndupload_register {
      * @return array File extensions to handle
      */
     public function get_extensions(): array {
-        return $this->extensions;
+        return array_values($this->extensions);
     }
 
     /**
@@ -57,6 +57,6 @@ final class dndupload_register {
      * @param string $ext Extension
      */
     public function register_handler(string $ext) {
-        $this->extensions[] = $ext;
+        $this->extensions[$ext] = $ext;
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -919,7 +919,6 @@ function videotime_cm_info_dynamic(cm_info $cm) {
 }
 
 /**
-<<<<<<< HEAD
  * Register the ability to handle drag and drop file uploads
  *
  * @return array containing details of the files / types the mod can handle

--- a/mod_form.php
+++ b/mod_form.php
@@ -405,15 +405,6 @@ class mod_videotime_mod_form extends moodleform_mod {
             );
             $defaultvalues['video_description']['itemid'] = $draftitemid;
 
-            foreach (array_keys(core_component::get_plugin_list('videotimeplugin')) as $name) {
-                component_callback("videotimeplugin_$name", 'data_preprocessing', [&$defaultvalues, $this->current->instance]);
-            }
-
-            foreach (array_keys(core_component::get_plugin_list('videotimetab')) as $name) {
-                $classname = "\\videotimetab_$name\\tab";
-                $classname::data_preprocessing($defaultvalues, $this->current->instance);
-            }
-
             $texttracks = $DB->get_records('videotime_track', ['videotime' => $this->current->instance]);
             $defaultvalues['trackid'] = array_keys($texttracks);
             $defaultvalues['tracklabel'] = array_values(array_column($texttracks, 'label'));
@@ -456,6 +447,15 @@ class mod_videotime_mod_form extends moodleform_mod {
                     );
                     $defaultvalues['texttrack'][$key] = $draftitemid;
                 }
+            }
+
+            foreach (array_keys(core_component::get_plugin_list('videotimeplugin')) as $name) {
+                component_callback("videotimeplugin_$name", 'data_preprocessing', [&$defaultvalues, $this->current->instance]);
+            }
+
+            foreach (array_keys(core_component::get_plugin_list('videotimetab')) as $name) {
+                $classname = "\\videotimetab_$name\\tab";
+                $classname::data_preprocessing($defaultvalues, $this->current->instance);
             }
         } else {
             $defaultvalues['tracktype'] = array_fill(
@@ -589,6 +589,14 @@ class mod_videotime_mod_form extends moodleform_mod {
             $trackno = 0;
         }
         $options = [];
+        if (
+            ($mediatimedata = json_decode(optional_param('mediatimedata', 'null', PARAM_RAW)))
+            && !empty($mediatimedata->texttracks)
+        ) {
+            $newtracks = (int)$mediatimedata->texttracks;
+        } else {
+            $newtracks = 1;
+        }
 
         $mform->setDefault('trackid', 0);
         $mform->setType('trackid', PARAM_INT);
@@ -600,7 +608,7 @@ class mod_videotime_mod_form extends moodleform_mod {
             $options,
             'tracks_repeats',
             'tracks_add_fields',
-            1,
+            $newtracks,
             get_string('addtexttrack', 'mod_videotime'),
             true,
             'delete'

--- a/mod_form.php
+++ b/mod_form.php
@@ -333,6 +333,7 @@ class mod_videotime_mod_form extends moodleform_mod {
         if (!isset($data['vimeo_url']) || empty($data['vimeo_url'])) {
             $fs = get_file_storage();
             if (
+                empty($data['mediatimeid']) &&
                 empty($data['livefeed']) && (
                 empty($data['mediafile'])
                 || !$files = $fs->get_area_files(context_user::instance($USER->id)->id, 'user', 'draft', $data['mediafile'])

--- a/plugin/videojs/classes/video_embed.php
+++ b/plugin/videojs/classes/video_embed.php
@@ -55,7 +55,7 @@ class video_embed extends vimeo_embed implements \renderable, \templatable {
      * @return \stdClass|array
      */
     public function export_for_template(renderer_base $output) {
-        global $CFG;
+        global $CFG, $DB, $OUTPUT;
 
         $mimetype = resourcelib_guess_url_mimetype($this->record->vimeo_url);
 
@@ -71,6 +71,12 @@ class video_embed extends vimeo_embed implements \renderable, \templatable {
                     $file->get_filepath(),
                     $file->get_filename()
                 )->out(false);
+            }
+        }
+        if (empty($poster) && !empty($this->record->mediatimeid) && $mediarecord = $DB->get_record('tool_mediatime', ['id' => $this->record->mediatimeid])) {
+            $resource = new \tool_mediatime\output\media_resource($mediarecord);
+            if ($url = $resource->image_url($OUTPUT)) {
+                $poster = $url;
             }
         }
 

--- a/plugin/videojs/lib.php
+++ b/plugin/videojs/lib.php
@@ -129,7 +129,7 @@ function videotimeplugin_videojs_delete_instance($id) {
  * @return object
  */
 function videotimeplugin_videojs_load_settings($instance) {
-    global $DB, $USER;
+    global $DB, $OUTPUT, $USER;
 
     $instance = (object) $instance;
     if (
@@ -178,6 +178,12 @@ function videotimeplugin_videojs_load_settings($instance) {
                 $instance['type'] = 'video/youtube';
             } else {
                 $instance['type'] = resourcelib_guess_url_mimetype($instance['vimeo_url']);
+            }
+        } else if (!empty($instance['mediatimeid']) && $mediarecord = $DB->get_record('tool_mediatime', ['id' => $instance['mediatimeid']])) {
+            $resource = new \tool_mediatime\output\media_resource($mediarecord);
+            if ($url = $resource->video_url($OUTPUT)) {
+                $instance['type'] = resourcelib_guess_url_mimetype($url) ?: 'video/m3u8';
+                $instance['vimeo_url'] = $url;
             }
         }
 
@@ -243,7 +249,7 @@ function videotimeplugin_videojs_embed_player($instance) {
 
     if (
         empty(get_config('videotimeplugin_videojs', 'enabled'))
-        || empty($instance->vimeo_url)
+        || (empty($instance->vimeo_url) && empty($instance->mediatimeid))
         || mod_videotime_get_vimeo_id_from_link($instance->vimeo_url)
     ) {
         return null;
@@ -411,6 +417,7 @@ function videotimeplugin_videojs_validation($data, $files) {
         || mod_videotime_get_vimeo_id_from_link($data['vimeo_url'])
         || (resourcelib_get_extension($data['vimeo_url']) == 'm3u8')
         || videotimeplugin_videojs_youtube($data['vimeo_url'])
+        || !empty($data['mediatimeid'])
     ) {
         $fs = get_file_storage();
         if (count($fs->get_area_files(\context_user::instance($USER->id)->id, 'user', 'draft', $data['mediafile'])) < 2) {

--- a/tab/embed/classes/privacy/provider.php
+++ b/tab/embed/classes/privacy/provider.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy provider.
+ *
+ * @package     videotimetab_embed
+ * @copyright   2026 bdecent gmbh <https://bdecent.de>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace videotimetab_embed\privacy;
+
+use core_privacy\local\metadata\null_provider;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy provider — this plugin stores no personal data.
+ *
+ * @package videotimetab_embed
+ */
+class provider implements null_provider {
+
+    /**
+     * Get the language string identifier explaining why this plugin stores no data.
+     *
+     * @return string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/tab/embed/classes/tab.php
+++ b/tab/embed/classes/tab.php
@@ -1,0 +1,202 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tab.
+ *
+ * @package     videotimetab_embed
+ * @copyright   2026 bdecent gmbh <https://bdecent.de>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace videotimetab_embed;
+
+use stdClass;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once("$CFG->dirroot/mod/videotime/lib.php");
+
+/**
+ * Embed tab — renders an admin-configured URL template as an iframe.
+ *
+ * The URL template may contain placeholders like {username}, {email}, etc.
+ * Each placeholder present in the template is replaced with the corresponding
+ * rawurlencode()-encoded value. Placeholders not present in the template are
+ * simply ignored.
+ *
+ * @package videotimetab_embed
+ */
+class tab extends \mod_videotime\local\tabs\tab {
+
+    /**
+     * Get tab panel content.
+     *
+     * @return string
+     */
+    public function get_tab_content(): string {
+        global $OUTPUT, $USER;
+
+        $instance = $this->get_instance();
+        $cm       = get_coursemodule_from_instance('videotime', $instance->id, $instance->course);
+        $course   = get_course($instance->course);
+        $videoid  = mod_videotime_get_vimeo_id_from_link($instance->vimeo_url ?? '') ?? '';
+
+        $template = (string) get_config('videotimetab_embed', 'embedurl');
+
+        $src = str_replace(
+            ['{username}', '{firstname}', '{email}',
+             '{courseshortname}', '{coursefullname}', '{courseidnumber}',
+             '{vtidnumber}', '{videoid}'],
+            array_map('rawurlencode', [
+                $USER->username    ?? '',
+                $USER->firstname   ?? '',
+                $USER->email       ?? '',
+                $course->shortname ?? '',
+                $course->fullname  ?? '',
+                $course->idnumber  ?? '',
+                $cm->idnumber      ?? '',
+                $videoid,
+            ]),
+            $template
+        );
+
+        return $OUTPUT->render_from_template('videotimetab_embed/tab', ['src' => $src]);
+    }
+
+    /**
+     * Whether the tab is enabled and visible.
+     *
+     * Returns false if the tab is not enabled for this instance, or if no
+     * embed URL template has been configured in admin settings.
+     *
+     * @return bool
+     */
+    public function is_visible(): bool {
+        global $DB;
+
+        if (!$this->is_enabled()) {
+            return false;
+        }
+        if (!trim((string) get_config('videotimetab_embed', 'embedurl'))) {
+            return false;
+        }
+        $record = $this->get_instance()->to_record();
+        return $DB->record_exists('videotimetab_embed', ['videotime' => $record->id]);
+    }
+
+    /**
+     * Defines the additional form fields.
+     *
+     * @param moodle_form $mform form to modify
+     */
+    public static function add_form_fields($mform) {
+        $mform->addElement(
+            'advcheckbox',
+            'enable_embed',
+            get_string('pluginname', 'videotimetab_embed'),
+            get_string('showtab', 'videotime')
+        );
+        $mform->setDefault('enable_embed', get_config('videotimetab_embed', 'default'));
+        $mform->disabledIf('enable_embed', 'enabletabs');
+
+        $mform->addElement('text', 'embedtab_name', get_string('embedtab_name', 'videotimetab_embed'));
+        $mform->setType('embedtab_name', PARAM_TEXT);
+        $mform->hideIf('embedtab_name', 'enable_embed', 'notchecked');
+
+        $mform->addElement('static', 'tab_separator_embed', '', '<hr class="mt-1 mb-2">');
+        $mform->hideIf('tab_separator_embed', 'enable_embed', 'notchecked');
+    }
+
+    /**
+     * Saves settings in database.
+     *
+     * @param stdClass $data Form data with values to save
+     */
+    public static function save_settings(stdClass $data) {
+        global $DB;
+
+        if (empty($data->enable_embed)) {
+            $DB->delete_records('videotimetab_embed', ['videotime' => $data->id]);
+        } else if ($record = $DB->get_record('videotimetab_embed', ['videotime' => $data->id])) {
+            $record->name = $data->embedtab_name ?? '';
+            $DB->update_record('videotimetab_embed', $record);
+        } else {
+            $DB->insert_record('videotimetab_embed', [
+                'videotime' => $data->id,
+                'name'      => $data->embedtab_name ?? '',
+            ]);
+        }
+    }
+
+    /**
+     * Delete settings in database.
+     *
+     * @param int $id videotime instance id
+     */
+    public static function delete_settings(int $id) {
+        global $DB;
+
+        $DB->delete_records('videotimetab_embed', ['videotime' => $id]);
+    }
+
+    /**
+     * Prepares the form before data are set.
+     *
+     * @param array $defaultvalues
+     * @param int   $instance
+     */
+    public static function data_preprocessing(array &$defaultvalues, int $instance) {
+        global $DB;
+
+        if (empty($instance)) {
+            $defaultvalues['enable_embed'] = get_config('videotimetab_embed', 'default');
+        } else if ($record = $DB->get_record('videotimetab_embed', ['videotime' => $instance])) {
+            $defaultvalues['enable_embed']  = 1;
+            $defaultvalues['embedtab_name'] = $record->name;
+        } else {
+            $defaultvalues['enable_embed'] = 0;
+        }
+    }
+
+    /**
+     * Get label for tab, using the custom name if one has been set.
+     *
+     * @return string
+     */
+    public function get_label(): string {
+        if ($label = $this->get_record()->name ?? '') {
+            return $label;
+        }
+        return parent::get_label();
+    }
+
+    /**
+     * List of missing dependencies needed for plugin to be enabled.
+     *
+     * Returns an upgrade-prompt HTML snippet when Video Time Pro is not
+     * installed, causing the base class to treat this tab as unavailable.
+     *
+     * @return string
+     */
+    public static function added_dependencies() {
+        global $OUTPUT;
+        if (videotime_has_pro()) {
+            return '';
+        }
+        return $OUTPUT->render_from_template('videotimetab_embed/upgrade', []);
+    }
+}

--- a/tab/embed/db/install.php
+++ b/tab/embed/db/install.php
@@ -1,0 +1,34 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Post-install script.
+ *
+ * @package     videotimetab_embed
+ * @copyright   2026 bdecent gmbh <https://bdecent.de>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Enable this plugin on new installs.
+ *
+ * @return bool
+ */
+function xmldb_videotimetab_embed_install() {
+    return true;
+}

--- a/tab/embed/db/install.xml
+++ b/tab/embed/db/install.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="mod/videotime/tab/embed/db" VERSION="20260312" COMMENT="XMLDB file for Moodle mod/videotime/tab/embed"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../../../lib/xmldb/xmldb.xsd"
+>
+  <TABLES>
+    <TABLE NAME="videotimetab_embed" COMMENT="Stores per-instance enable state for the Embed tab">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="videotime" TYPE="int" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="name" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Custom tab label"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="videotime" TYPE="foreign-unique" FIELDS="videotime" REFTABLE="videotime" REFFIELDS="id" COMMENT="Video time instance"/>
+      </KEYS>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/tab/embed/db/upgrade.php
+++ b/tab/embed/db/upgrade.php
@@ -1,0 +1,48 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Upgrade steps for videotimetab_embed.
+ *
+ * @package     videotimetab_embed
+ * @copyright   2026 bdecent gmbh <https://bdecent.de>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Execute videotimetab_embed upgrade steps.
+ *
+ * @param int $oldversion
+ * @return bool
+ */
+function xmldb_videotimetab_embed_upgrade($oldversion) {
+    global $DB;
+
+    $dbman = $DB->get_manager();
+
+    if ($oldversion < 2026031201) {
+        $table = new xmldb_table('videotimetab_embed');
+        $field = new xmldb_field('name', XMLDB_TYPE_TEXT, null, null, null, null, null, 'videotime');
+
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_plugin_savepoint(true, 2026031201, 'videotimetab', 'embed');
+    }
+
+    return true;
+}

--- a/tab/embed/lang/en/videotimetab_embed.php
+++ b/tab/embed/lang/en/videotimetab_embed.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Plugin strings are defined here.
+ *
+ * @package     videotimetab_embed
+ * @copyright   2026 bdecent gmbh <https://bdecent.de>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['default']          = 'Default';
+$string['embedtab_name']    = 'Custom tab name';
+$string['default_help']     = 'Whether the tab is enabled by default for new activities.';
+$string['embedurl']         = 'Embed URL';
+$string['embedurl_help']    = 'URL of the tool to embed as an iframe. Use placeholders to inject context values — each placeholder is replaced with its URL-encoded value at render time. Only placeholders you include in the URL are used; unused ones are ignored.
+
+Available placeholders:
+{username} — Moodle username
+{firstname} — User\'s first name
+{email} — User\'s email address
+{courseshortname} — Course short name
+{coursefullname} — Course full name
+{courseidnumber} — Course ID number
+{vtidnumber} — Video Time activity ID number
+{videoid} — Vimeo video ID (numeric, extracted from the activity URL)
+
+Example: https://myapp.com/tool?user={username}&email={email}&course={courseshortname}';
+$string['label']            = 'Embed';
+$string['pluginname']       = 'Embed tab';
+$string['privacy:metadata'] = 'The Embed tab plugin does not store any personal data.';
+$string['upgradeplugin']    = 'This plugin requires installation of Video Time Pro to enable.';

--- a/tab/embed/settings.php
+++ b/tab/embed/settings.php
@@ -1,0 +1,42 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Plugin administration pages are defined here.
+ *
+ * @package     videotimetab_embed
+ * @category    admin
+ * @copyright   2026 bdecent gmbh <https://bdecent.de>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+// PARAM_RAW is required because PARAM_URL strips the { } placeholder characters.
+$settings->add(new admin_setting_configtext(
+    'videotimetab_embed/embedurl',
+    new lang_string('embedurl', 'videotimetab_embed'),
+    new lang_string('embedurl_help', 'videotimetab_embed'),
+    '',
+    PARAM_RAW
+));
+
+$settings->add(new admin_setting_configcheckbox(
+    'videotimetab_embed/default',
+    new lang_string('default', 'videotimetab_embed'),
+    new lang_string('default_help', 'videotimetab_embed'),
+    0
+));

--- a/tab/embed/templates/tab.mustache
+++ b/tab/embed/templates/tab.mustache
@@ -1,0 +1,40 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template videotimetab_embed/tab
+
+    Renders an iframe with the admin-configured URL (placeholders already substituted by PHP).
+
+    Variables required for this template:
+    * src - The fully resolved iframe URL (triple-mustache to avoid HTML-encoding ampersands)
+
+    Example context (json):
+    {
+        "src": "https://myapp.com/tool?user=john&email=john%40example.com"
+    }
+}}
+<div class="videotimetab_embed h-100">
+    <iframe
+        src="{{{ src }}}"
+        width="100%"
+        height="100%"
+        frameborder="0"
+        allow="autoplay; fullscreen"
+        allowfullscreen
+        style="min-height: 400px;"
+    ></iframe>
+</div>

--- a/tab/embed/templates/upgrade.mustache
+++ b/tab/embed/templates/upgrade.mustache
@@ -1,0 +1,32 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template videotimetab_embed/upgrade
+
+    Shown in the mod_form when Pro is not installed.
+
+    Variables optional for this template:
+
+    Example context (json):
+    {
+    }
+
+}}
+<div class="text-info">
+     {{# str }} upgradeplugin, videotimetab_embed {{/ str }}
+     <a href="https://bdecent.de/product/video-time-pro">{{# str }} moreinfo {{/ str }}</a>
+</div>

--- a/tab/embed/tests/tab_test.php
+++ b/tab/embed/tests/tab_test.php
@@ -1,0 +1,260 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for the Embed tab plugin.
+ *
+ * @package     videotimetab_embed
+ * @copyright   2026 bdecent gmbh <https://bdecent.de>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace videotimetab_embed;
+
+use advanced_testcase;
+use mod_videotime\videotime_instance;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once("$CFG->dirroot/mod/videotime/tab/embed/db/install.php");
+
+/**
+ * Tests for videotimetab_embed.
+ *
+ * @group videotimetab_embed
+ * @group mod_videotime
+ * @covers \videotimetab_embed\tab
+ */
+final class tab_test extends advanced_testcase {
+
+    /** @var \stdClass */
+    private $course;
+
+    /** @var \stdClass generated videotime module record */
+    private $modulerecord;
+
+    /** @var videotime_instance */
+    private $instance;
+
+    /** @var \stdClass test user */
+    private $user;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+
+        $this->course = $this->getDataGenerator()->create_course([
+            'shortname' => 'TEST101',
+            'fullname'  => 'Test Course',
+            'idnumber'  => 'COURSE-001',
+        ]);
+        $this->modulerecord = $this->getDataGenerator()->create_module('videotime', [
+            'course'    => $this->course->id,
+            'vimeo_url' => 'https://vimeo.com/347119375',
+        ]);
+        $this->instance = videotime_instance::instance_by_id($this->modulerecord->id);
+
+        $this->user = $this->getDataGenerator()->create_user([
+            'username'  => 'testuser',
+            'firstname' => 'Jane',
+            'email'     => 'jane@example.com',
+        ]);
+        $this->setUser($this->user);
+    }
+
+    // -------------------------------------------------------------------------
+    // Install function
+    // -------------------------------------------------------------------------
+
+    /**
+     * The install function must exist and return true.
+     *
+     * This test would have caught the missing-install-function upgrade error
+     * (same class of bug as in videotimetab_liveinteraction).
+     */
+    public function test_install_function_exists_and_returns_true(): void {
+        $this->assertTrue(
+            function_exists('xmldb_videotimetab_embed_install'),
+            'xmldb_videotimetab_embed_install() must be defined in db/install.php'
+        );
+        $this->assertTrue(xmldb_videotimetab_embed_install());
+    }
+
+    // -------------------------------------------------------------------------
+    // is_visible()
+    // -------------------------------------------------------------------------
+
+    /**
+     * Tab is not visible when no DB record exists (not enabled for the instance).
+     */
+    public function test_is_visible_false_when_not_enabled(): void {
+        set_config('embedurl', 'https://example.com/tool', 'videotimetab_embed');
+
+        $tab = new tab($this->instance);
+        $this->assertFalse($tab->is_visible());
+    }
+
+    /**
+     * Tab is not visible when enabled per-instance but no URL is configured.
+     */
+    public function test_is_visible_false_when_no_url_configured(): void {
+        global $DB;
+
+        set_config('embedurl', '', 'videotimetab_embed');
+        $DB->insert_record('videotimetab_embed', ['videotime' => $this->modulerecord->id]);
+
+        $tab = new tab($this->instance);
+        $this->assertFalse($tab->is_visible());
+    }
+
+    /**
+     * Tab is visible when enabled per-instance and a URL template is configured.
+     */
+    public function test_is_visible_true_when_enabled_and_url_configured(): void {
+        global $DB;
+
+        set_config('embedurl', 'https://example.com/tool', 'videotimetab_embed');
+        $DB->insert_record('videotimetab_embed', ['videotime' => $this->modulerecord->id]);
+
+        $tab = new tab($this->instance);
+        $this->assertTrue($tab->is_visible());
+    }
+
+    // -------------------------------------------------------------------------
+    // Placeholder substitution
+    // -------------------------------------------------------------------------
+
+    /**
+     * {username} placeholder is replaced with the current user's username.
+     */
+    public function test_placeholder_username_substituted(): void {
+        set_config('embedurl', 'https://example.com/tool?u={username}', 'videotimetab_embed');
+
+        $tab     = new tab($this->instance);
+        $content = $tab->get_tab_content();
+
+        $this->assertStringContainsString('u=testuser', $content);
+        $this->assertStringNotContainsString('{username}', $content);
+    }
+
+    /**
+     * {email} placeholder is replaced with the current user's email address.
+     */
+    public function test_placeholder_email_substituted(): void {
+        set_config('embedurl', 'https://example.com/tool?mail={email}', 'videotimetab_embed');
+
+        $tab     = new tab($this->instance);
+        $content = $tab->get_tab_content();
+
+        $this->assertStringContainsString('mail=jane%40example.com', $content);
+        $this->assertStringNotContainsString('{email}', $content);
+    }
+
+    /**
+     * {courseshortname} placeholder is replaced with the course short name.
+     */
+    public function test_placeholder_course_substituted(): void {
+        set_config('embedurl', 'https://example.com/tool?c={courseshortname}', 'videotimetab_embed');
+
+        $tab     = new tab($this->instance);
+        $content = $tab->get_tab_content();
+
+        $this->assertStringContainsString('c=TEST101', $content);
+        $this->assertStringNotContainsString('{courseshortname}', $content);
+    }
+
+    /**
+     * Placeholders NOT present in the URL template are not injected into the output.
+     */
+    public function test_unused_placeholders_not_in_output(): void {
+        // Template uses only {username} — {email} literal brace syntax must not appear.
+        set_config('embedurl', 'https://example.com/tool?u={username}', 'videotimetab_embed');
+
+        $tab     = new tab($this->instance);
+        $content = $tab->get_tab_content();
+
+        $this->assertStringNotContainsString('{email}', $content);
+        $this->assertStringNotContainsString('jane%40example.com', $content);
+    }
+
+    /**
+     * {videoid} placeholder is replaced with the numeric Vimeo video ID.
+     */
+    public function test_placeholder_videoid_for_vimeo_url(): void {
+        // Vimeo plugin must be enabled for mod_videotime_get_vimeo_id_from_link() to work.
+        set_config('enabled', 1, 'videotimeplugin_vimeo');
+        set_config('embedurl', 'https://example.com/tool?v={videoid}', 'videotimetab_embed');
+
+        $tab     = new tab($this->instance);
+        $content = $tab->get_tab_content();
+
+        $this->assertStringContainsString('v=347119375', $content);
+    }
+
+    // -------------------------------------------------------------------------
+    // Custom tab name
+    // -------------------------------------------------------------------------
+
+    /**
+     * get_label() returns the custom name when one is stored.
+     */
+    public function test_get_label_returns_custom_name(): void {
+        global $DB;
+
+        $DB->insert_record('videotimetab_embed', [
+            'videotime' => $this->modulerecord->id,
+            'name'      => 'My Custom Tool',
+        ]);
+
+        $tab = new tab($this->instance);
+        $this->assertSame('My Custom Tool', $tab->get_label());
+    }
+
+    /**
+     * get_label() falls back to the default lang string when no custom name is set.
+     */
+    public function test_get_label_falls_back_to_default(): void {
+        global $DB;
+
+        $DB->insert_record('videotimetab_embed', [
+            'videotime' => $this->modulerecord->id,
+            'name'      => '',
+        ]);
+
+        $tab = new tab($this->instance);
+        $this->assertSame(get_string('label', 'videotimetab_embed'), $tab->get_label());
+    }
+
+    /**
+     * Placeholder values containing special characters are rawurlencode()-encoded.
+     */
+    public function test_placeholder_values_are_url_encoded(): void {
+        global $DB;
+
+        // Give the user a name with a space and an apostrophe.
+        $DB->set_field('user', 'firstname', "O'Brien Smith", ['id' => $this->user->id]);
+        $this->user->firstname = "O'Brien Smith";
+
+        set_config('embedurl', 'https://example.com/tool?name={firstname}', 'videotimetab_embed');
+
+        $tab     = new tab($this->instance);
+        $content = $tab->get_tab_content();
+
+        // rawurlencode turns space → %20, apostrophe → %27.
+        $this->assertStringContainsString('name=O%27Brien%20Smith', $content);
+    }
+}

--- a/tab/embed/version.php
+++ b/tab/embed/version.php
@@ -1,0 +1,34 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Plugin version and other meta-data are defined here.
+ *
+ * @package     videotimetab_embed
+ * @copyright   2026 bdecent gmbh <https://bdecent.de>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component    = 'videotimetab_embed';
+$plugin->release      = '1.0';
+$plugin->version      = 2026031201;
+$plugin->requires     = 2015111610;
+$plugin->maturity     = MATURITY_STABLE;
+$plugin->dependencies = [
+    'mod_videotime' => 2023011200,
+];

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_videotime';
-$plugin->release = '1.10.2';
-$plugin->version = 2025102502;
+$plugin->release = '1.11';
+$plugin->version = 2026022000;
 $plugin->requires = 2024041600;
 $plugin->supported = [404, 501];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
A new videotimetab_embed subplugin that renders an admin-configured URL as a full-width <iframe> inside a Video Time tab. The URL is a template: before the iframe is rendered, a fixed set of placeholders ({username}, {email}, {firstname}, {courseshortname}, {coursefullname}, {courseidnumber}, {vtidnumber}, {videoid}) are replaced with rawurlencode()-encoded values from the current user/course/activity context. Unused placeholders are silently ignored.

The intended use case is embedding an external tool (LTI-like, analytics dashboard, interactive companion app, etc.) alongside the video without leaving the activity page.