### PR TITLE
VID-1187: Update monochrome activity icon asset (monologo.svg)

### DIFF
--- a/pix/monologo.svg
+++ b/pix/monologo.svg
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="70px" height="78px" viewBox="0 0 70 78" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 57.1 (83088) - https://sketch.com -->
-    <title>Path 2 Copy 2</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-        <g id="Artboard" transform="translate(-203.000000, -116.000000)" stroke="#000000" stroke-width="6">
-            <polygon id="Path-2-Copy-2" points="206 119 270 153.025364 206 191 213.378115 153.025364"></polygon>
-        </g>
-    </g>
+<svg id="Ebene_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: none;
+        stroke: #000;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+    </style>
+  </defs>
+  <path class="cls-1" d="M4.63,2.83l14.91,8.57c.44.25.44.89,0,1.14l-14.88,8.63c-.47.28-1.06-.11-.98-.66l1.13-8.43c0-.06,0-.12,0-.18L3.65,3.49c-.08-.54.51-.94.98-.66Z"/>
 </svg>


### PR DESCRIPTION
## Description
This PR replaces the legacy flat monochrome activity icon (`monologo.svg`) with the newly redesigned asset for Video Time.

## Changes Made
* Updated `pix/monologo.svg` with the updated vector assets.